### PR TITLE
Disable root cert loading

### DIFF
--- a/src/lib/BaseStub.php
+++ b/src/lib/BaseStub.php
@@ -57,9 +57,16 @@ class BaseStub
      */
     public function __construct($hostname, $opts, Channel $channel = null)
     {
-        $ssl_roots = file_get_contents(
-            dirname(__FILE__).'/../../etc/roots.pem');
-        ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        // https://github.com/grpc/grpc/issues/11632
+        // Because we only ever use "insecure connections" by talking to linkerd
+        // or gRPC over HTTP, we can comment the below root cert loading out until
+        // the above issue is fixed
+        // $ssl_roots = file_get_contents(
+        //     dirname(__FILE__).'/../../etc/roots.pem');
+        // ChannelCredentials::setDefaultRootsPem($ssl_roots);
+        if (array_key_exists('credentials', $opts) && $opts['credentials'] !== null) {
+            throw new \Exception("Credentialed connections (SSL, etc) are unsupported until until grpc/grpc #11632 is resolved");
+        }
 
         $this->hostname = $hostname;
         $this->update_metadata = null;


### PR DESCRIPTION
https://github.com/grpc/grpc/issues/11632

> setDefaultRootsPem() is allocating a memory buffer large enough to contain the roots pem. The memory buffer is never freed. Calling setDefaultRootsPem() multiple times will allocate the buffer again, and leak more memory:

We think this is the cause of a bunch of problems we've seen with the gRPC client in production of late. We don't use credentialed connections to linkerd/with gRPC right now, so I'm removing the call to `setDefaultRootsPem` until the above is fixed.

I've also made the client error out if anything but `ChannelCredentials::createInsecure` (`null`) is passed.

Needs testing.